### PR TITLE
(MAINT) Reduce and Improve Knack Table

### DIFF
--- a/manuscript/02-character-creation/g-knacks.md
+++ b/manuscript/02-character-creation/g-knacks.md
@@ -3,8 +3,11 @@
 Knacks are special abilities characters can possess, tied to _who they are_ and _what they repeatedly do_ - a character's knacks are a statement about a character's _gestalt_, the qualities which are more than the sum of a character's individual parts.
 Knacks derive from personality traits, behaviors, vocations, and core beliefs.
 
-Characters begin play with three randomly determined knacks at magnitude 3.
-To determine a new knack, roll a d8 on the formula table and then a d30 four times to determine the quirk, form, effect, and element.
+Characters begin play with a randomly determined knack at magnitude 3.
+
+To determine a new knack, roll a d8 on the formula table and then a d20 four times to determine the quirk, form, effect, and element.
+Alternatively, for faster generation, roll a d8 on the formula table and then a d20 once, reading directly across the second table to determine the quirk, form, effect, and element.
+
 If the combination doesn't make sense, roll again or pick an appropriate option from the list.
 
 Some knacks may be predetermined and provided by the referee as resulting from a particular organization, skill, or vocation.
@@ -19,44 +22,34 @@ Note that this limits the maximum magnitude of any given knack, not the total ma
 |    1    | (Physical Quirk) (Physical Form) of (Ethereal Effect) (Ethereal Element) |
 |    2    | (Physical Quirk) (Physical Form) of (Ethereal Effect) (Physical Element) |
 |    3    | (Physical Quirk) (Physical Form) of (Physical Effect) (Physical Element) |
-|    4    | (Physical Quitk) (Physical Form) of (Physical Effect) (Ethereal Element) |
+|    4    | (Physical Quirk) (Physical Form) of (Physical Effect) (Ethereal Element) |
 |    5    | (Ethereal Quirk) (Ethereal Form) of (Ethereal Effect) (Ethereal Element) |
 |    6    | (Ethereal Quirk) (Ethereal Form) of (Ethereal Effect) (Physical Element) |
 |    7    | (Ethereal Quirk) (Ethereal Form) of (Physical Effect) (Physical Element) |
-|    8    | (Ethereal Quitk) (Ethereal Form) of (Physical Effect) (Ethereal Element) |
+|    8    | (Ethereal Quirk) (Ethereal Form) of (Physical Effect) (Ethereal Element) |
 
-| Roll d30 | Physical Quirk | Physical Form | Ethereal Quirk | Ethereal Form | Physical Effect | Ethereal Effect | Physical Element | Ethereal Element |
+| Roll d20 | Physical Quirk | Physical Form | Ethereal Quirk | Ethereal Form | Physical Effect | Ethereal Effect | Physical Element | Ethereal Element |
 |:--------:|:--------------:|:-------------:|:--------------:|:-------------:|:---------------:|:---------------:|:----------------:|:----------------:|
-|    01    | Atrophied      | Ankle         | Soft           | Aura          | Animating       | Avenging        | Acid             | Ash              |
-|    02    | Bevelled       | Arm           | Ringing        | Bile          | Attracting      | Banishing       | Amber            | Chaos            |
-|    03    | Bloody         | Back          | Metallic       | Blood         | Binding         | Bewildering     | Bark             | Distortion       |
-|    04    | Burned         | Body          | Congealed      | Blush         | Blossoming      | Blinding        | Blood            | Dream            |
-|    05    | Dark           | Brow          | Bitter         | Breath        | Consuming       | Charming        | Bone             | Dust             |
-|    06    | Extra          | Cheek         | Sweet          | Hearing       | Creeping        | Compelling      | Brine            | Fire             |
-|    07    | Gnarled        | Chest         | Lingering      | Heart         | Crushing        | Concealing      | Clay             | Fog              |
-|    08    | Hairy          | Ear           | Sharp          | Laugh         | Diminishing     | Deafening       | Crow             | Harmony          |
-|    09    | Jeweled        | Elbow         | Dull           | Liver         | Duplicating     | Deceiving       | Crystal          | Heat             |
-|    10    | Large          | Eye           | Full           | Marrow        | Enveloping      | Disguising      | Ember            | Light            |
-|    11    | Long           | Finger        | Sickly         | Mind          | Expanding       | Dispelling      | Fungus           | Lightning        |
-|    12    | Muscular       | Foot          | Harsh          | Mood          | Fusing          | Emboldening     | Glass            | Memory           |
-|    13    | Pale           | Hair          | Burning        | Movement      | Hastening       | Energizing      | Honey            | Mutation         |
-|    14    | Polished       | Hand          | Icy            | Phlegm        | Hindering       | Enlightening    | Ice              | Negation         |
-|    15    | Rough          | Jaw           | Smooth         | Presence      | Illuminating    | Enraging        | Insect           | Plague           |
-|    16    | Sandy          | Knee          | Staggered      | Reflection    | Imprisoning     | Excruciating    | Wood             | Probability      |
-|    17    | Scaled         | Lips          | Memorable      | Scent         | Opening         | Intoxicating    | Lava             | Rain             |
-|    18    | Scarred        | Nail          | Bland          | Sense         | Petrifying      | Maddening       | Moss             | Rot              |
-|    19    | Short          | Neck          | Pungent        | Shadow        | Phasing         | Mesmerizing     | Obsidian         | Shadow           |
-|    20    | Small          | Nose          | Clear          | Sight         | Piercing        | Mindreading     | Oil              | Smoke            |
-|    21    | Smooth         | Nostril       | Repuslive      | Sound         | Pursuing        | Nullifying      | Poison           | Snow             |
-|    22    | Spiked         | Palm          | Hastened       | Echo          | Reflecting      | Paralyzing      | Rat              | Soul             |
-|    23    | Split          | Shoulder      | Hardened       | Sweat         | Rending         | Revealing       | Sand             | Star             |
-|    24    | Sticky         | Skin          | Resonant       | Taste         | Repelling       | Revolting       | Serpent          | Stasis           |
-|    25    | Swollen        | Skull         | Stinging       | Tears         | Screaming       | Silencing       | Slime            | Steam            |
-|    26    | Symetrical     | Stomache      | Shimmering     | Timbre        | Sealing         | Soothing        | Stone            | Thunder          |
-|    27    | Thick          | Teeth         | Fearsome       | Touch         | Shapeshifting   | Terrifying      | Thorn            | Time             |
-|    28    | Thin           | Toe           | Animalistic    | Vitality      | Shielding       | Warding         | Vine             | Warp             |
-|    29    | Twisted        | Tongue        | Ancient        | Voice         | Spawning        | Wearying        | Water            | Whisper          |
-|    30    | Wiry           | Bones         | Weak           | Yawn          | Transmuting     | Withering       | Wood             | Wind             |
+|    01    | Atrophied      | Arm           | Animalistic    | Hearing       | Piercing        | Revealing       | Flesh            | Memory           |
+|    02    | Bloody         | Eye           | Burning        | Blood         | Spawning        | Excruciating    | Bone             | Dream            |
+|    03    | Burned         | Hair          | Dull           | Taste         | Diminishing     | Soothing        | Brine            | Thunder          |
+|    04    | Gnarled        | Lips          | Fearsome       | Echo          | Consuming       | Energizing      | Metal            | Chaos            |
+|    05    | Hairy          | Palm          | Full           | Blush         | Animating       | Bewildering     | Plant            | Belief           |
+|    06    | Jeweled        | Nail          | Hardened       | Shadow        | Crushing        | Withering       | Fungus           | Hope             |
+|    07    | Large          | Ear           | Harsh          | Breath        | Attracting      | Avenging        | Insect           | Fear             |
+|    08    | Muscular       | Stomache      | Hastened       | Voice         | Duplicating     | Warding         | Stone            | Pain             |
+|    09    | Polished       | Nose          | Icy            | Laugh         | Sealing         | Compelling      | Mouth            | Harmony          |
+|    10    | Sandy          | Cheek         | Lingering      | Yawn          | Hindering       | Concealing      | Muscle           | Violence         |
+|    11    | Scaled         | Skin          | Metallic       | Tears         | Enveloping      | Mesmerizing     | Serpent          | Whisper          |
+|    12    | Scarred        | Jaw           | Repuslive      | Phlegm        | Opening         | Deceiving       | Portal           | Intent           |
+|    13    | Small          | Teeth         | Resonant       | Presence      | Illuminating    | Enlightening    | Blood            | Intellect        |
+|    14    | Spiked         | Brow          | Ringing        | Sweat         | Imprisoning     | Emboldening     | Thorn            | Knowledge        |
+|    15    | Split          | Tongue        | Sharp          | Mind          | Reflecting      | Intoxicating    | Silver           | Secret           |
+|    16    | Sticky         | Finger        | Shimmering     | Marrow        | Petrifying      | Silencing       | Slime            | Peace            |
+|    17    | Swollen        | Skull         | Sickly         | Reflection    | Screaming       | Banishing       | Crystal          | Faith            |
+|    18    | Thick          | Hand          | Smooth         | Movement      | Hastening       | Terrifying      | Smoke            | Hunger           |
+|    19    | Twisted        | Neck          | Soft           | Touch         | Bending         | Disguising      | Wood             | Surety           |
+|    20    | Wiry           | Foot          | Stinging       | Scent         | Repelling       | Enraging        | Drake            | Friendship       |
 
 Once you've determined the description of the knack the referee describes the knack's general effects based on its name and works with you to explain how it ties into your character's gestalt.
 If a knack is related to a vocation, skill, or relationship its magnitude can never exceed the 10s place of the relevant bonus (in addition to the limitation on all knacks imposed by your Power score).

--- a/manuscript/05-combat.md
+++ b/manuscript/05-combat.md
@@ -1,0 +1,69 @@
+-# Combat
+
+Occasionally, everything will go very wrong (or, more rarely, very right) and characters will find themselves in a fight.
+The rules in this chapter explain how combat works, building on top of the core rules.
+
+## Moment By Moment
+
+When combat breaks out, time is counted mechanically in moments - roughly three seconds each - during which initiative order is followed.
+
+At the beginning of each moment, everyone involved in the combat makes an opposed INT test.
+From worst result to best, the players declare their characters' intended actions and reactions.
+In reverse order the actions take place and are adjudicated; reactions take place when triggered.
+
+In a moment, a character can make one action and reaction without penalty.
+If a character wants to perform two actions they may forego their reaction and vice versa.
+A character may take an additional action or reaction without forgoing another, but all of their tests are one step harder as a result.
+A character may also forego an action or reaction to focus on just the one thing, making the test one step easier.
+
+- Actions include, but are not limited to, the following:
+  - **Attacking:** an attacking character makes a BOD test adding a skill or vocation bonus as normal.
+    If the target doesn't use a reaction against the attack and the test result is a success, the character inflicts damage per their weapon on the target.
+    Alternatively, an attack can be used to reposition, disarm, or grapple an opponent or otherwise impose your will on them.
+  - **Moving:** a character can move somewhere nearby as an action, or somewhere distant if they use both their action and their reaction.
+  - Other actions, like throwing a grappling hook, drinking a potion, using a matrix or scroll - they don't require specific rules, the referee can make sensible rulings as the game goes - but it **is** important that those rulings remain _consistent_ during play.
+- Reactions include, but are not limited to, the following:
+  - **Parrying:** choose to bat aside an incoming attack by making an opposed BOD test.
+  - **Blocking:** choose to position your shield in front of an incoming attack by making an easy opposed BOD test; if successful, reduce the usage die of the shield by one step.
+  - **Dodging:** choose to try to move out of the way of an incoming attack by making a hard opposed BOD test.
+  - Interfering with another action will always be contextual and require a ruling from the referee, but normally an opposed test of some sort will be the right call.
+
+## Injury and Recovery
+
+When a character takes damage that their armor points can't soak, they lose hit points.
+When a character reaches 0 hit points they are dead.
+
+### Major Wounds
+
+If a character loses at least half their current hitpoints from a single instantaneous source they suffer a major wound per the table below.
+Some results on the table includes a value for a dice roll in parentheses, like `(d6)`.
+After a character suffers a major wound they make a death test by rolling that die and adding any listed bonus; if the result is greater than or equal to the sizr of the die, the character dies from their wound.
+Otherwise, they'll survive, provided they get competent medical attention quickly.
+
+If the result on the table is something that could be on either side of the body, it is on the left if the last rolled test result was even and on the right side if it was odd.
+
+| Roll d12 | Body Part | Crushing                                             | Slicing                          | Piercing                                                                      |
+|:--------:|:---------:|:-----------------------------------------------------|:---------------------------------|:------------------------------------------------------------------------------|
+|     1    | Foot      | Foot crushed, walk slowly with a limp                | Foot cut off (d6+1)              | Foot stabbed through, limp til healed (d10)                                   |
+|     2    | Leg       | Femur cracked, walk slowly until healed              | Femoral artery sliced (d4+1)     | Thigh pierced,  painful flesh wound, slowing movement til healed (d6)         |
+|     3    | Hand      | Fingers crushed, unable to hold anything securely    | Hand cut off (d6+1)              | Hand stabbed through, unable to hold anything til healed (d10)                |
+|     4    | Arm       | Forearm broken, can't hold anything heavy til healed | Arm cut off at the elbow (d4+1)  | Forearm pierced, painful flesh wound, hard to hold anything til healed (d8+1) |
+|     5    | Belly     | Ruptured Spleen (d6+1)                               | Intestines falling out (d6+2)    | Aorta severed (d4+2)                                                          |
+|     6    | Chest     | Collapsed Lung (d6+1)                                | Sliced pectoral (d10)            | Pierced Heart, death                                                          |
+|     7    | Neck      | Broken Neck (d4+2)                                   | Slit throat, death               | Stabbed in the throat (d4+2)                                                  |
+|     8    | Cheek     | Shattered cheek, concussion (d4)                     | Cheek sliced open to mouth (d10) | Broken teeth and severed tongue (d6)                                          |
+|     9    | Eye       | Broken eye socket, eye pulverized (d6+1)             | Ear cut off                      | Lost eye (d4+1)                                                               |
+|    10    | Skull     | Shattered skull (d4+2)                               | Skull cracked (d6)               | Pierced skull (d4)                                                            |
+|    11    | Nose      | Crushed face (d6)                                    | Nose cut off (d10)               | Nose split (d4+1)                                                             |
+|    12    | Ear       | Oozing Brains, death                                 | Ear cut off (d10)                | Ear split (d4+2)                                                              |
+
+### Medical attention
+
+Anyone can try to provide medical attention to an injured character by making a hard INT test for each wound sustained.
+For each success, they heal 1d4 HP.
+
+If the test is a failure, no HP are restored and the character may not try to heal that wound again until they improve a medical skill or vocation.
+
+### Natural Healing
+
+For every week of relative rest a character regains 1HP.

--- a/manuscript/Book.txt
+++ b/manuscript/Book.txt
@@ -19,3 +19,4 @@ introduction.md
 04-supplication.md
 04-supplication/a-ranks.md
 04-supplication/b-miracles.md
+05-combat.md


### PR DESCRIPTION
It is unlikely most players will have access to a d30 to generate a
knack at character creation. This change cuts the list of possible
combinations down to 20 for each category, enabling a tighter list
of knacks whose combinations make more sense. This still leaves us
with over a million possible combinations and (assuming only 10% are
valid), over a hundred thousand possible knacks.