### PR TITLE
(MAINT) Rename HP & PP to Blood & Tephra

### DIFF
--- a/manuscript/02-character-creation/b-attributes.md
+++ b/manuscript/02-character-creation/b-attributes.md
@@ -1,15 +1,20 @@
 # Calculating Attributes
 
 Once you have rolled for your starting characteristics you can determine your attributes.
-These are pools of points which represent your ability to sustain damage (in the case of hit points) and use magic or special abilities (in the case of power points).
+These are pools of points which represent your ability to sustain damage (in the case of Blood) and use magic or special abilities (in the case of Tephra).
 
-+ **Hit Points (HP):** Add your character's Bone and Iron - the 'tens' digit is their HP.
-+ **Power Points (PP):** Add your character's Flax and Iron - the 'tens' digit is their PP.
++ **Blood:** Add your character's Bone and Iron - the 'tens' digit is their Blood.
+  In Pentola, citizens refer to how thick or thin someone's blood is as a metaphor for how tough they are, or how much danger seems to affect them.
+  People who are thick-blooded stride through dangers recklessly, coming out relatively unscathed, and survive injuries you would expect to be lethal.
+  When someone's luck seems to be running out in a fight, Pentolans will oft remark on their thinning blood.
++ **Tephra:** Add your character's Flax and Iron - the 'tens' digit is their Tephra.
+  Pentolans describe people as being heavy with Tephra if they are intrinsically powerful or adept at magic, believing them to be literally full of magic.
+  If someone is light on Tephra or has been dropping it, Pentolans believe they are not capable of much more magic... at least, not without thinning their blood dangerously.
 
 {icon=dice-d20}
 G> #### Example Determining Attributes for Taryn
 G>
 G> Having rolled the characteristics for Taryn we can calculate their attributes:
 G>
-G> + Hit Points: With a Bone of 51 and a Iron of 18 (total of 69), Taryn's HP is 6.
-G> + Power Points: With an Flax of 44 and a Iron of 18 (total of 62), Taryn's PP is 6.
+G> + Blood: With a Bone of 51 and a Iron of 18 (total of 69), Taryn's Blood is 6.
+G> + Tephra: With an Flax of 44 and a Iron of 18 (total of 62), Taryn's Tephra is 6.

--- a/manuscript/02-character-creation/g-knacks.md
+++ b/manuscript/02-character-creation/g-knacks.md
@@ -14,8 +14,8 @@ If the combination doesn't make sense, roll again or pick an appropriate option 
 Some knacks may be predetermined and provided by the referee as resulting from a particular organization, skill, or vocation.
 
 Knacks gained after character creation always start at magnitude 1.
-The maximum magnitude of any knack is limited by a character's max PP.
-For example, a character with a PP of 6 could not have any knacks whose magnitude was 7 or higher.
+The maximum magnitude of any knack is limited by a character's max Tephra.
+For example, a character with a Tephra of 6 could not have any knacks whose magnitude was 7 or higher.
 Note that this limits the maximum magnitude of any given knack, not the total magnitude of knacks a character can acquire.
 
 | Roll d8 |                               Description                                |
@@ -112,20 +112,20 @@ G> The effected targets also test Iron and add their highest relevant bonus, if 
 A character does not need to make any tests to exercise a knack because the ability is an extension of who they are (though an opposed test may need to be made to effect the target as normal).
 It uses some metaphysical energy that they experience as a growing sense of hunger and ache in their bones, but does not otherwise tire them.
 
-If a character has no power points to spend on exercising a knack they may instead make a Power test and spend HP equal to the magnitude of the knack they are attempting to exercise.
-Note that the HP is lost _whether or not_ they succeed on the test as they burn some of their life force to power the attempt.
+If a character has no power points to spend on exercising a knack they may instead make a Power test and spend Blood equal to the magnitude of the knack they are attempting to exercise.
+Note that the Blood is lost _whether or not_ they succeed on the test as they burn some of their life force to power the attempt.
 Failure indicates that they simply couldn't control it.
 
 {icon=dice-d20}
-G> #### Example: Exercising a Knack with 0 PP
+G> #### Example: Exercising a Knack with 0 Tephra
 G> Taryn chooses to exercise their "Polished Scent of Sealing Harmony" knack in response to escalating tensions between two factions in a last ditch attempt to prevent violence from breaking out.
-G> They have the knack at a magnitude 5 and choose to exercise it as such, but have no PP left.
+G> They have the knack at a magnitude 5 and choose to exercise it as such, but have no Tephra left.
 G>
-G> Taryn taps into their life force, making a Iron test and succeeding; their current HP decreases by 5.
+G> Taryn taps into their life force, making a Iron test and succeeding; their current Blood decreases by 5.
 G> They then make an opposed test against everyone nearby, testing their Iron with a +50% bonus from the knack's magnitude.
 G> The effected targets also test Iron and add the highest relevant bonus, if any.
 G>
-G> **Note:** If Taryn had failed their Iron test to exercise the knack they would _still_ have had their current HP decrease by 5.
+G> **Note:** If Taryn had failed their Iron test to exercise the knack they would _still_ have had their current Blood decrease by 5.
 
 ## Improving Knacks
 

--- a/manuscript/02-character-creation/i-wealth-and-equipment.md
+++ b/manuscript/02-character-creation/i-wealth-and-equipment.md
@@ -115,9 +115,9 @@ G> If Taryn wanted to instead increase their wealth from Average to Wealthy, the
 
 ## Encumbrance
 
-A character can carry a number of items equal to their max HP with no issues.
+A character can carry a number of items equal to their max Blood with no issues.
 Carrying over this amount means they are encumbered and all tests are one step harder - they can also only ever move to somewhere nearby in a moment.
-They simply cannot carry more than double their max HP.
+They simply cannot carry more than double their max Blood.
 
 Note that some items can increase your encumbrance maximum by making carrying items easier.
 

--- a/manuscript/03-craft.md
+++ b/manuscript/03-craft.md
@@ -68,7 +68,7 @@ G>
 G> Alessia could choose to apply a dweomer with a magnitude of 4 (4 complexity), a Duration of 4 hours (6 complexity), and a range of one furlong (4 complexity) for a total of 14 complexity.
 G>
 G> If she chooses to apply it as an action she can handle a complexity of up to 3 on each of the dweom'ers effects - up to a total complexity of 12, no single effect with a rating higher than 3.
-G> If she botches the test for application, she'll take damage equal to the complexity she attempted; that damage can only be mitigated by permanently burning one power point per hit point spared.
+G> If she botches the test for application, she'll take damage equal to the complexity she attempted; that damage can only be mitigated by permanently burning one Tephra per Blood spared.
 
 | Complexity  | Magnitude |  Duration  |    Range    |        Volume       |
 |:-----------:|:---------:|:----------:|:-----------:|:-------------------:|
@@ -141,7 +141,7 @@ In general, tests to apply a dweomer as an action are one step harder if in mele
 
 Failing the test indicates that the crafter was unable to correctly adjudicate the energy and manipulations correctly and has caused a _misapplication_ - see the table below.
 Botching the test causes the crafter to take damage equal to the complexity of the dweomer in a special misapplication known as _Tephratic Feedback_.
-This damage cannot be reduced by AP, but a crafter can divert some of this damage by permanently reducing their power point total by one for each hit point they choose not to lose.
+This damage cannot be reduced by AP, but a crafter can divert some of this damage by permanently reducing their Tephra total by one for each point of Blood they choose not to lose.
 The power points can be sourced from a charm, but it cannot be refilled if used in this way.
 
 | 1D8 | Misapplication Effect |
@@ -150,7 +150,7 @@ The power points can be sourced from a charm, but it cannot be refilled if used 
 |  2  | **Burn:** The dweomer burns through the crafter, the magical energy misdirect. Take 1D4 damage.
 |  3  | **Explosion:** The energy of the dweomer goes off catastrophically, causing an explosion whose diameter is equal to the range of the dweomer. The explosion inflicts damage equal to half the total complexity to everyone in the sphere.
 |  4  | **Blind:** the dweomer's energy radiates as a brilliant light centered on the crafter, blinding them and anyone who looks at them in the next moment.
-|  5  | **Overpower:** The dweomer is applied but with more power than intended; double the magnitude of the dweomer but pay the additional complexity from the crafter's PP, dealing damage equal to the amount they cannot pay, if any.
+|  5  | **Overpower:** The dweomer is applied but with more power than intended; double the magnitude of the dweomer but pay the additional complexity from the crafter's Tephra, dealing damage equal to the amount they cannot pay, if any.
 |  6  | **Memory Loss:** Applying the dweomer without the appropriate safeguards caused the magic to burn the crafter's mind, making them lose some of what they've learned about the craft, though it does still take effect. Reduce the character's crafting skill bonus by a number of points equal to the magnitude of the dweomer.
 |  7  | **Weak:** The dweomer is successfully applied, but without any of the intended manipulations.
 |  8  | **Delayed:** The crafter fails to apply the dweomer in _this_ moment but may still apply it in the _next_ one automatically and without an additional test.

--- a/manuscript/03-craft/a-dweomers.md
+++ b/manuscript/03-craft/a-dweomers.md
@@ -59,7 +59,7 @@ G> If there's an effect which makes sense given the dweomer's description the re
 |   19-20   | Copy                         | Touch                        | Make a copy of an inanimate item which lasts for the duration.
 |   21-22   | Corrode (Substance)          | Permanent                    | Cause a particular inorganic substance to rapidly lose structural integrity.
 |   23-24   | Counterdweomer               | Reaction                     | Reactively ullify the effects of a dweomer being applied.
-|   25-26   | Create Charm                 | Permanent                    | Store **M PP** into a valuable item for later use (must spend **M PP** as well); make refillable by spending **1 IP**.
+|   25-26   | Create Charm                 | Permanent                    | Store **M Tephra** into a valuable item for later use (must spend **M Tephra** as well); make refillable by spending **1 IP**.
 |   27-28   | Create Ephemer               | Permanent                    | Combine with another dweomer to store into a single one-use item which can, with a crafting test, be released later.
 |   29-30   | Create Matrix                | Permanent                    | Create an item which contains a M dweomers and allows the wielder to apply and manipulate them using your Crafting skill bonus; Make reusable by spending **M IP**.
 |   31-32   | Demoralize / Galvanize       | Resist, Concentration        | Sew doubt and uncertainty or confidence and aggression into targets, making all combat tests one step harder/easier.

--- a/manuscript/03-craft/b-alchemy.md
+++ b/manuscript/03-craft/b-alchemy.md
@@ -31,7 +31,7 @@ The potency of any effects caused by a mishap is equal to the intended magnitude
 | Roll 2d10 | Alchemical Mishap |
 |:---------:|:------------------|
 |     02    | **Perfection:** The experiment goes unpredictably perfect, the delay is the minimum for the form and the duration and batch size the maximum, but no matter how hard the alchemist tries, the formula can not be repeated.
-|     03    | **Overpowered:** This batch of the formula is more powerful intended with double the magnitude. However, it makes up for this extra magnitude with PP from whoever uses the batch as the included ingredients cannot supply it.
+|     03    | **Overpowered:** This batch of the formula is more powerful intended with double the magnitude. However, it makes up for this extra magnitude with Tephra from whoever uses the batch as the included ingredients cannot supply it.
 |     04    | **Euphoria:** The formula is made correctly, but to take any of it will induce a state of extreme euphoria for the duration in addition to any other effects.
 |     05    | **Blood Bubbling:** The batch causes the blood to turn partially to gas in the body of anyone who takes it, inducing terrible pain and halving their body score for the duration.
 |     06    | **Vanishing:** The batch hardens and then crumbles into infinitely small grains, dispersing at the slightest motion.
@@ -39,16 +39,16 @@ The potency of any effects caused by a mishap is equal to the intended magnitude
 |     08    | **Fulmination:** The experiment literally blows up as the magic energies mix with too much volatility, inflicting M damage on those who are nearby.
 |     09    | **Burning:** The formula burns uncontrollably, igniting a hot conflagration that consumes the ingredients and possibly nearby equipment.
 |     10    | **Sickening:** The formula is a failure, noxious gases escaping and causing everyone nearby to vomit uncontrollably for 1d6 moments.
-|     11    | **Slippage:** The formula is a failure and drains the alchemist of 1d4 PP as the magical energies fluctuate dangerously.
+|     11    | **Slippage:** The formula is a failure and drains the alchemist of 1d4 Tephra as the magical energies fluctuate dangerously.
 |     12    | **Underpowered:** The formula is "successful" but only at magnitude 1.
 |     13    | **Disorienting:** The formula is "successful" but includes a side effect which makes all Flax tests hard for the duration.
-|     14    | **Spillage:** The batch expands beyond its containers, spilling onto everything near by and causing chemical burns (1d6 HP) to everything it touches.
+|     14    | **Spillage:** The batch expands beyond its containers, spilling onto everything near by and causing chemical burns (1d6 Blood) to everything it touches.
 |     15    | **Shattering:** The batch petrifies everything close, shattering into dangerous shards in 1d4 moments.
 |     16    | **Freezing:** The batch sucks all of the heat from the area nearby, freezing everything solid in 1d6 moments.
 |     17    | **Maddening:** The fumes from this batch rapidly expand to fill the room, inducing a random madness in those who breath it in.
 |     18    | **Puddling:** The noxious particles from this failed batch destabilize any solids they come in contact with, causing them to liquify.
 |     19    | **Necrotizing:** This batch bubbles over and expands violently, seeking out living flesh nearby and causing it to begin to rot immediately.
-|     20    | **Tephratic Inversion:** The experiment goes horribly awry as magic itself burns out, drawing all nearby magic and energy into it at a rate of 2d4 PP / moment. When the PP is drained from nearby living creatures it instead drains HP until death or escape. This terrible mishap will drain the magic from creatures and items alike, destroying them.
+|     20    | **Tephratic Inversion:** The experiment goes horribly awry as magic itself burns out, drawing all nearby magic and energy into it at a rate of 2d4 Tephra / moment. When the Tephra is drained from nearby living creatures it instead drains Blood until death or escape. This terrible mishap will drain the magic from creatures and items alike, destroying them.
 
 ## Producing Alchemical Items
 

--- a/manuscript/03-craft/c-art.md
+++ b/manuscript/03-craft/c-art.md
@@ -77,7 +77,7 @@ G> ~ Letter from an Aydinlar Merchant to her Cousin
 Actualizing an ethereal opus takes 1 minute per point of complexity to perform instead of the normal time.
 It takes effect either at completion (starting the duration clock), or begins immediately but lasts only for so long as the performance does.
 
-Actualizing an ethereal opus spends 1PP for every 5 points of complexity.
+Actualizing an ethereal opus spends 1 Tephra for every 5 points of complexity.
 This cost can be spent from charms or other sources as normal.
 
 {icon=wrench}
@@ -92,6 +92,6 @@ G> It can make the game feel more distinct and strange, a feeling Pentola was wr
 
 Creating an ethereal opus follows the same rules as researching a dweomer, except that:
 
-- you must also expend all of your PP in the attempt as the process is intense and draws directly from your every reserve
+- you must also expend all of your Tephra in the attempt as the process is intense and draws directly from your every reserve
 - each created opus with a roll of 2-3 has some slight, but fading effect related to your research goal
 - each created opus with a roll of 1 has an unexpected or backfiring effect compared to your research goal

--- a/manuscript/04-supplication.md
+++ b/manuscript/04-supplication.md
@@ -44,7 +44,7 @@ A character who is a supplicant, principal, or champion can call upon their gran
 They may even do so if dead or unconscious, as long as it is called for in the instant that consciousness fades or death occurs.
 
 When intervention is requested, roll 1D100.
-If this roll is equal to or less than the character's max PP, the call for aid is answered.
+If this roll is equal to or less than the character's max Tephra, the call for aid is answered.
 However, grantors demand a heavy price for their help and the character will suffer a permanent loss from their relationship bonus equal to the roll, if they are successful.
 
 Intervention can take many forms and the following can be considered guidelines:

--- a/manuscript/04-supplication/b-miracles.md
+++ b/manuscript/04-supplication/b-miracles.md
@@ -19,7 +19,7 @@ The exact effects are up to the referee and player to decide but will automatica
 
 Performing a miracle is automatically successful.
 No dice need be rolled, no chance of a botch or critical either.
-Miracles do not cost any PP and always take only a single action to perform.
+Miracles do not cost any Tephra and always take only a single action to perform.
 
 A character can dismiss any miracle they have performed as a single action.
 Ceasing to perform a concentration miracle is immediate and does not require an action.
@@ -83,12 +83,12 @@ The character need not spend any improvement points to regain their miracles.
 |:------------------:|:--------------------------------------------------------------:|:------------|
 | Abjure             | Area (Nearby), Duration (M hours), Progressive, Resist         | Surround a spherical area with a shimmering globe which deflects missiles of any size harmlessly and which any hostile creature must overcome. Any incoming effect with a magnitude lower than this miracle fails to pierce it.
 | Age                | Permanent, Progressive, Resist, Touch                          | The target ages by one decade per magnitude of this miracle.
-| Banish             | Duration (M days), Progressive, Resist                         | The target must move out of sight of the supplicant and cannot willingly approach them for the duration; every moment in which the target is in the presence of the supplicant they lose 1HP and 1PP as the curse eats away at them.
+| Banish             | Duration (M days), Progressive, Resist                         | The target must move out of sight of the supplicant and cannot willingly approach them for the duration; every moment in which the target is in the presence of the supplicant they lose 1 Blood and 1 Tephra as the curse eats away at them.
 | Bind               | Concentration, Resist, Magnitude 3                             | The target is held perfectly still for the duration and can move only as much as the supplicant wills, if at all.
 | Burden             | Duration (1 day), Resist, Magnitude 2                          | The target is crushed under the weight of this miracle as though carrying the heaviest load they are capable of.
 | Command            | Permanent, Progressive, Resist                                 | The target is compelled to carry out the letter of a given command to the best of their ability - they are free to interpret it in their own interests. For each point of magnitude the command may contain one additional word.
 | Compel Truth       | Concentration, Magnitude 3, Resist                             | The target cannot knowingly speak any falsehoods for the duration and must give as much and complete an accounting as they are capable of.
-| Conflagrate        | Progressive, Area (Nearby), Ranged (Far), Dodge, Concentration | An area within range ignites with a flame wrought of pure power, consuming 1d4HP and PP each moment while it burns.
+| Conflagrate        | Progressive, Area (Nearby), Ranged (Far), Dodge, Concentration | An area within range ignites with a flame wrought of pure power, consuming 1d4 Blood and Tephra each moment while it burns.
 | Control Weather    | Magnitude 5, Area (Far)                                        | The supplicant is able to control the weather for as far as they can see, summoning or dismissing storms, wind, and clouds.
 | Deny               | Progressive, Instant                                           | The supplicant can use this miracle in response to any other being channelled to disrupt it - if successful, the targeted supplicant counts as having channeled the miracle for all purposes but no effects manifest.
 | Dismiss Magic      | Progressive, Instant                                           | The supplicant can use this miracle to end the effects of any and all other magics on a target which have a lower magnitude.
@@ -97,7 +97,7 @@ The character need not spend any improvement points to regain their miracles.
 | Drown              | Concentration, Resist, Magnitude 3                             | For the duration of this miracle the target drowns on dry land, their lungs filling with liquid no matter how hard they try to breathe.
 | Endless Hunger     | Permanent, Resist, Magnitude 2                                 | No matter what the target eats, they will forever suffer from hunger pains as though their last meal was before this miracle took effect.
 | Excommunicate      | Permanent, Resist                                              | When channeled upon a member of the same organization this miracle cuts them off entirely from their miracles and knacks until they get another grantor to apply the ritual of supplication to them again.
-| Exsanguinate       | Duration (1 minute), Touch, Resist, Magnitude 5                | For one minute after this miracle is channeled the target bleeds profusely from every orifice and sweats blood, losing 1d4 HP / moment.
+| Exsanguinate       | Duration (1 minute), Touch, Resist, Magnitude 5                | For one minute after this miracle is channeled the target bleeds profusely from every orifice and sweats blood, losing 1d4 Blood / moment.
 | Glassheart         | Duration (M hours), Progressive, Resist                         | For the duration the target is particularly prone to fear and frayed nerves, breaking under the slightest pressure. All opposed tests are one step harder for the duration.
 | Gravetouch         | Permanent, Magnitude 5, Resist                                 | Death comes for the target once this miracle has been channeled upon them; they take double damage from all sources and find all combat tests one step harder.
 | Hear Truth         | Concentration                                                  | For the duration the supplicant will know whether anyone speaking is telling the truth or being intentionally misleading.

--- a/manuscript/05-combat.md
+++ b/manuscript/05-combat.md
@@ -30,8 +30,8 @@ A character may also forego an action or reaction to focus on just the one thing
 
 ## Injury and Recovery
 
-When a character takes damage that their armor points can't soak, they lose hit points.
-When a character reaches 0 hit points they are dead.
+When a character takes damage that their armor points can't soak, they lose Blood.
+When a character reaches 0 Blood, all additional damage inflicts major wounds.
 
 <!-- TODO: Add an option for not-dying at 0 and one less brutal? -->
 
@@ -62,10 +62,10 @@ If the result on the table is something that could be on either side of the body
 ### Medical attention
 
 Anyone can try to provide medical attention to an injured character by making a hard Flax test for each wound sustained.
-For each success, they heal 1d3 HP up to the injured character's maximum HP.
+For each success, the injured character recover1 1d3 Blood, up to their maximum Blood.
 
-If the test is a failure, no HP are restored and the character may not try to heal that wound again until they improve a medical skill or vocation.
+If the test is a failure, no Blood is restored and the character may not try to heal that wound again until they improve a medical skill or vocation.
 
 ### Natural Healing
 
-For every week of relative rest a character regains 1HP.
+For every week of relative rest a character regains 1 Blood.


### PR DESCRIPTION
Prior to this commit the rules referenced hit points and power points,
a hold over from trad ganmes it drew inspiration from; however, as the
other stats had been renamed to be diegetic, it made sense to update
the derived stats as well.